### PR TITLE
Update `rdkit` call (maxAttempts -> maxIterations)

### DIFF
--- a/radonpy/core/utils.py
+++ b/radonpy/core/utils.py
@@ -1187,7 +1187,7 @@ def mol_from_smiles(smiles, coord=True, version=2, ez='E', chiral='S'):
         etkdg = AllChem.ETKDG()
     etkdg.enforceChirality=True
     etkdg.useRandomCoords = False
-    etkdg.maxAttempts = 100
+    etkdg.maxIterations = 500
 
     try:
         mol = Chem.MolFromSmiles(smi)


### PR DESCRIPTION
The object calls for a deprecated instance of etkdg in remit. I can provide the versions in the following comment.